### PR TITLE
media-libs/openimageio: fix various minor issues

### DIFF
--- a/media-libs/openimageio/metadata.xml
+++ b/media-libs/openimageio/metadata.xml
@@ -11,7 +11,7 @@
 		<flag name="field3d">Enable f3d file (write) support via <pkg>media-libs/Field3D</pkg></flag>
 		<flag name="heif"> Add support for HEIF format via <pkg>media-libs/libheif</pkg></flag>
 		<flag name="opencv">Enable OpenCV support via <pkg>media-libs/opencv</pkg></flag>
-		<flag name="openvdb"  restrict="&gt;=media-libs/openimageio-2.0">Enable OpenVDB read support via <pkg>media-libs/openvdb</pkg></flag>
+		<flag name="openvdb"  restrict="&gt;=media-libs/openimageio-2.0">Enable OpenVDB read support via <pkg>media-gfx/openvdb</pkg></flag>
 		<flag name="openvdb_abi_5" restrict="&gt;=media-libs/openimageio-2.0">
 			Support legacy ABI version 5 for
 			<pkg>media-gfx/openvdb</pkg>.


### PR DESCRIPTION
- change one pkg spec in metadata.xml from media-libs/openvdb to
	media-gfx/openvdb
- remove ssl and libressl USE flags. I didn't found any trace for
	dependencies on SSL. Also comment the argument to cmake for
	SSL.
- change USE dep default for doxygen[latex], due to new version no
	longer ships this USE flag
- add openimageio.pdf to DOCS only when USE=doc is present and the
	file is actually built
- add '|| die' to sed statements in src_prepare. Also add missing '\'
	chars to some of them to ensure proper expanding
- change -DUSE_OCIO to -DUSE_OpenColorIO. The former has caused a
	warning in cmake for a defined but unused variable

Signed-off-by: Bernd Waibel <waebbl@gmail.com>

Note: I didn't resolve various fatal errors from older versions reported by repoman full, therefore commited directly via git and not repoman.
